### PR TITLE
Bug fixes

### DIFF
--- a/backend/core/auth/auth_oidc_provider.py
+++ b/backend/core/auth/auth_oidc_provider.py
@@ -229,7 +229,7 @@ class AuthOidcProvider(AuthProvider):
         try:
             # Manually build the authorization URL
             auth_endpoint = discovery_doc["authorization_endpoint"]
-            scopes = " ".join(config["scopes"])
+            scopes = config["scopes"]
 
             params = {
                 "client_id": config["client_id"],


### PR DESCRIPTION
When using OIDC, the scope parameter was incorrectly split into single letters.