### PR TITLE
feat: --all flag for image prune

### DIFF
--- a/backend/alembic/versions/43f46d0c1bfd_added_host_prune_all.py
+++ b/backend/alembic/versions/43f46d0c1bfd_added_host_prune_all.py
@@ -1,0 +1,39 @@
+"""added host.prune_all
+
+Revision ID: 43f46d0c1bfd
+Revises: 74c15c1c767e
+Create Date: 2025-11-18 02:05:40.678029
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "43f46d0c1bfd"
+down_revision: Union[str, Sequence[str], None] = "74c15c1c767e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("hosts") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "prune_all",
+                sa.Boolean(),
+                default=False,
+                server_default=sa.text("(FALSE)"),
+                nullable=False,
+            )
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("hosts") as batch_op:
+        batch_op.drop_column("prune_all")

--- a/backend/api/images_api.py
+++ b/backend/api/images_api.py
@@ -55,10 +55,10 @@ async def get_list(
 
 @router.post(path="/{host_id}/prune", response_model=str)
 async def prune(
-    host_id: int, session: AsyncSession = Depends(get_async_session)
+    host_id: int,
+    body: PruneImagesRequestBodySchema,
+    session: AsyncSession = Depends(get_async_session),
 ) -> str:
     host = await get_host(host_id, session)
     client = HostsManager.get_host_client(host)
-    return await client.image.prune(
-        PruneImagesRequestBodySchema(all=True)
-    )
+    return await client.image.prune(body)

--- a/backend/core/containers_core.py
+++ b/backend/core/containers_core.py
@@ -473,15 +473,22 @@ async def check_host(
 
         if host.prune:
             CACHE.update({"status": ECheckStatus.PRUNING})
-            output = await client.image.prune(
-                PruneImagesRequestBodySchema(all=True)
-            )
-            lines = [
-                line.strip()
-                for line in output.splitlines()
-                if line.strip()
-            ]
-            result.prune_res = lines[-1] if lines else None
+            logging.info(f"Pruning images on host '{host.name}'")
+            try:
+                output = await client.image.prune(
+                    PruneImagesRequestBodySchema(all=host.prune_all)
+                )
+                lines = [
+                    line.strip()
+                    for line in output.splitlines()
+                    if line.strip()
+                ]
+                result.prune_res = lines[-1] if lines else None
+            except Exception as e:
+                logging.exception(e)
+                logging.error(
+                    f"Failed to prune images on host '{host.name}'"
+                )
 
         CACHE.update({"status": ECheckStatus.DONE})
         return result

--- a/backend/db/models/containers_model.py
+++ b/backend/db/models/containers_model.py
@@ -22,10 +22,10 @@ class ContainersModel(BaseModel):
     __tablename__ = "containers"
 
     id: Mapped[int] = mapped_column(
-        Integer, primary_key=True, index=True, nullable=False
+        Integer, primary_key=True, nullable=False
     )
     host_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("hosts.id"), index=True, nullable=False
+        Integer, ForeignKey("hosts.id"), nullable=False
     )
     name: Mapped[str] = mapped_column(
         String, index=True, nullable=False

--- a/backend/db/models/hosts_model.py
+++ b/backend/db/models/hosts_model.py
@@ -30,6 +30,12 @@ class HostsModel(BaseModel):
         default=False,
         server_default=text("FALSE"),
     )
+    prune_all: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=text("FALSE"),
+    )
     url: Mapped[str] = mapped_column(
         String,
         nullable=False,

--- a/backend/readme.md
+++ b/backend/readme.md
@@ -21,4 +21,4 @@ PASSWORD_FILE=password_hash
 
 ### Migrations
 
-Do not forget to create new migrations on models change with `alembic revision --autogenerate -m "some column add to some table"`
+Do not forget to create new migrations on models change with `alembic -c backend/alembic.ini revision --autogenerate -m "..."`

--- a/backend/schemas/hosts_schema.py
+++ b/backend/schemas/hosts_schema.py
@@ -6,6 +6,7 @@ class HostBase(BaseModel):
     name: str
     enabled: bool
     prune: bool
+    prune_all: bool
     url: str
     secret: Optional[str] = None
     timeout: int

--- a/frontend/public/i18n/en.json
+++ b/frontend/public/i18n/en.json
@@ -83,6 +83,8 @@
         "ENABLED": "Enabled",
         "PRUNE": "Prune",
         "PRUNE_HINT": "Enable auto-pruning of images after scheduled process.",
+        "PRUNE_ALL": "Prune all",
+        "PRUNE_ALL_HINT": "This toggle stands for --all flag of 'docker image prune' command.",
         "URL": "Agent address",
         "URL_PLACEHOLDER": "http://127.0.0.1:8001",
         "SECRET": "Agent secret",
@@ -126,6 +128,8 @@
     "TABLE": {
       "PRUNE": "Prune",
       "PRUNE_CONFIRM": "Do you want to prune images?",
+      "PRUNE_ALL": "Prune all",
+      "PRUNE_ALL_HINT": "This toggle stands for --all flag of 'docker image prune' command.",
       "PRUNE_RESULT": "Prune result",
       "SEARCH_PLACEHOLDER": "ID, repo, tags",
       "REPOSITORY": "Repository",

--- a/frontend/src/app/entities/hosts/hosts-interface.ts
+++ b/frontend/src/app/entities/hosts/hosts-interface.ts
@@ -2,6 +2,7 @@ export interface ICreateHost {
   name: string;
   enabled: boolean;
   prune: boolean;
+  prune_all: boolean;
   url: string;
   secret: string;
   timeout: number;

--- a/frontend/src/app/entities/images/images-api.service.ts
+++ b/frontend/src/app/entities/images/images-api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BaseApiService } from '../base/base-api.service';
 import { Observable } from 'rxjs';
-import { IImage } from './images-interface';
+import { IImage, IPruneImageRequestBodySchema } from './images-interface';
 
 @Injectable({
   providedIn: 'root',
@@ -13,7 +13,7 @@ export class ImagesApiService extends BaseApiService<'/images'> {
     return this.httpClient.get<IImage[]>(`${this.basePath}/${host_id}/list`);
   }
 
-  prune(host_id: number): Observable<string> {
-    return this.httpClient.post<string>(`${this.basePath}/${host_id}/prune`, {});
+  prune(host_id: number, body: IPruneImageRequestBodySchema): Observable<string> {
+    return this.httpClient.post<string>(`${this.basePath}/${host_id}/prune`, body);
   }
 }

--- a/frontend/src/app/entities/images/images-interface.ts
+++ b/frontend/src/app/entities/images/images-interface.ts
@@ -7,6 +7,10 @@ export interface IImage {
   size: number;
 }
 
+export interface IPruneImageRequestBodySchema {
+  all: boolean;
+}
+
 export interface IImagePruneResult {
   ImagesDeleted: { [K: string]: string }[];
   SpaceReclaimed: number;

--- a/frontend/src/app/features/hosts-page/hosts-page-card/hosts-page-card.html
+++ b/frontend/src/app/features/hosts-page/hosts-page-card/hosts-page-card.html
@@ -56,7 +56,12 @@
             <label for="host-enabled">
               {{ 'HOSTS.CARD.GENERAL.ENABLED' | translate }}
             </label>
+          </span>
 
+          <span
+            class="switch-field"
+            fluid
+          >
             <p-toggle-switch
               [inputId]="'host-prune'"
               formControlName="prune"
@@ -67,6 +72,20 @@
                 class="pi pi-question-circle"
                 style="margin: 0 0.5rem"
                 [pTooltip]="'HOSTS.CARD.GENERAL.PRUNE_HINT' | translate"
+                tooltipPosition="left"
+              ></i>
+            </label>
+
+            <p-toggle-switch
+              [inputId]="'host-prune-all'"
+              formControlName="prune_all"
+            ></p-toggle-switch>
+            <label for="host-prune-all">
+              {{ 'HOSTS.CARD.GENERAL.PRUNE_ALL' | translate }}
+              <i
+                class="pi pi-question-circle"
+                style="margin: 0 0.5rem"
+                [pTooltip]="'HOSTS.CARD.GENERAL.PRUNE_ALL_HINT' | translate"
                 tooltipPosition="left"
               ></i>
             </label>

--- a/frontend/src/app/features/hosts-page/hosts-page-card/hosts-page-card.ts
+++ b/frontend/src/app/features/hosts-page/hosts-page-card/hosts-page-card.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   inject,
   OnInit,
   signal,
@@ -69,6 +70,7 @@ export class HostsPageCard implements OnInit {
   private readonly translateService = inject(TranslateService);
   private readonly router = inject(Router);
   private readonly confirmationService = inject(ConfirmationService);
+  private readonly destroyRef = inject(DestroyRef);
 
   public readonly id = toSignal(
     this.activatedRoute.params.pipe(map((params) => Number(params.id) || null)),
@@ -86,6 +88,7 @@ export class HostsPageCard implements OnInit {
     return {
       enabled: true,
       prune: false,
+      prune_all: false,
       timeout: 5,
     };
   }
@@ -94,6 +97,7 @@ export class HostsPageCard implements OnInit {
     name: new FormControl<string>(null, [Validators.required]),
     enabled: new FormControl<boolean>(null, [Validators.required]),
     prune: new FormControl<boolean>(null, [Validators.required]),
+    prune_all: new FormControl<boolean>(null, [Validators.required]),
     url: new FormControl<string>(null, [Validators.required]),
     secret: new FormControl<string>(null),
     timeout: new FormControl<number>(null, [Validators.required]),
@@ -102,6 +106,17 @@ export class HostsPageCard implements OnInit {
   ngOnInit(): void {
     const id = this.id();
     this.getInfo(id);
+    this.form.controls.prune.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value) => {
+        const prune_all = this.form.controls.prune_all;
+        if (!value) {
+          prune_all.setValue(false);
+          prune_all.disable();
+        } else {
+          prune_all.enable();
+        }
+      });
   }
 
   private getInfo(id: number): void {

--- a/frontend/src/app/features/images-page/images-page-table/images-page-table.html
+++ b/frontend/src/app/features/images-page/images-page-table/images-page-table.html
@@ -1,4 +1,41 @@
-<p-confirmpopup></p-confirmpopup>
+<p-confirmpopup #pruneConfirmPopup>
+  <ng-template
+    #content
+    let-message
+  >
+    <section
+      [ngStyle]="{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.5rem',
+      }"
+    >
+      <span>{{ message.message }}</span>
+      <span
+        [ngStyle]="{
+          display: 'inline-flex',
+          gap: '0.5rem',
+          alignItems: 'center',
+        }"
+      >
+        <p-toggle-switch
+          [(ngModel)]="pruneAll"
+          inputId="prune-all-confirm-toggle"
+        ></p-toggle-switch>
+        <label for="prune-all-confirm-toggle">
+          {{ 'IMAGES.TABLE.PRUNE_ALL' | translate }}
+          <i
+            class="pi pi-question-circle"
+            style="margin: 0 0.5rem"
+            [pTooltip]="'IMAGES.TABLE.PRUNE_ALL_HINT' | translate"
+            tooltipPosition="left"
+          ></i>
+        </label>
+      </span>
+    </section>
+  </ng-template>
+</p-confirmpopup>
+
 <p-table
   #dt2
   [globalFilterFields]="['id', 'repository', 'tags']"

--- a/frontend/src/app/features/images-page/images-page-table/images-page-table.ts
+++ b/frontend/src/app/features/images-page/images-page-table/images-page-table.ts
@@ -1,5 +1,14 @@
-import { DatePipe, DecimalPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, input, OnInit, signal } from '@angular/core';
+import { DatePipe, DecimalPipe, NgStyle } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+  model,
+  OnInit,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
@@ -11,12 +20,13 @@ import { InputIconModule } from 'primeng/inputicon';
 import { InputTextModule } from 'primeng/inputtext';
 import { TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
 import { TooltipModule } from 'primeng/tooltip';
 import { finalize } from 'rxjs';
 import { ToastService } from 'src/app/core/services/toast.service';
 import { IHostInfo } from 'src/app/entities/hosts/hosts-interface';
 import { ImagesApiService } from 'src/app/entities/images/images-api.service';
-import { IImage } from 'src/app/entities/images/images-interface';
+import { IImage, IPruneImageRequestBodySchema } from 'src/app/entities/images/images-interface';
 
 @Component({
   selector: 'app-images-page-table',
@@ -34,6 +44,9 @@ import { IImage } from 'src/app/entities/images/images-interface';
     TooltipModule,
     DecimalPipe,
     DialogModule,
+    ToggleSwitchModule,
+    FormsModule,
+    NgStyle,
   ],
   providers: [ConfirmationService],
   templateUrl: './images-page-table.html',
@@ -51,6 +64,10 @@ export class ImagesPageTable implements OnInit {
   public readonly isLoading = signal<boolean>(false);
   public readonly pruneResult = signal<string>(null);
   public readonly list = signal<IImage[]>([]);
+  /**
+   * Prune all flag for confirmation popup toggle
+   */
+  public readonly pruneAll = model<boolean>(false);
 
   ngOnInit(): void {
     this.updateList();
@@ -97,9 +114,12 @@ export class ImagesPageTable implements OnInit {
 
   private prune(): void {
     const host = this.host();
+    const body: IPruneImageRequestBodySchema = {
+      all: this.pruneAll(),
+    };
     this.isLoading.set(true);
     this.imagesApiService
-      .prune(host.id)
+      .prune(host.id, body)
       .pipe(
         finalize(() => {
           this.isLoading.set(false);

--- a/shared/schemas/image_schemas.py
+++ b/shared/schemas/image_schemas.py
@@ -16,7 +16,7 @@ class GetImageListBodySchema(BaseModel):
 
 
 class PruneImagesRequestBodySchema(BaseModel):
-    all: Optional[bool] = True
+    all: Optional[bool] = False
     filters: Optional[dict[str, Any]] = {}
 
 


### PR DESCRIPTION
+ added migration with hosts.prune_all field
+ added support of --all flag for image pruning (auto and manual)
+ fixed backend readme migration command
+ removed indexes in ContainersModel (typo), indexes was not created in the migrations
+ changed default value of all (prune schema) to false

Related to #22