### PR TITLE
feat: add trust_env=True to aiohttp

### DIFF
--- a/backend/api/public_api.py
+++ b/backend/api/public_api.py
@@ -187,7 +187,7 @@ async def is_update_available():
     if Config.GH_TOKEN:
         headers["Authorization"] = f"Bearer {Config.GH_TOKEN}"
     async with aiohttp.ClientSession(
-        headers=headers, timeout=aiohttp.ClientTimeout(15)
+        headers=headers, timeout=aiohttp.ClientTimeout(15), trust_env=True
     ) as session:
         async with session.request(
             "GET",

--- a/backend/core/agent_client.py
+++ b/backend/core/agent_client.py
@@ -79,6 +79,7 @@ class AgentClient:
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=timeout),
             json_serialize=custom_json_dumps,
+            trust_env=True,
         ) as session:
             async with session.request(
                 method,

--- a/backend/core/auth/auth_oidc_provider.py
+++ b/backend/core/auth/auth_oidc_provider.py
@@ -204,7 +204,7 @@ class AuthOidcProvider(AuthProvider):
     ) -> dict[str, Any]:
         """Fetch OIDC discovery document from well-known URL"""
         try:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(trust_env=True) as session:
                 async with session.get(well_known_url) as response:
                     if response.status == 200:
                         return await response.json()
@@ -271,7 +271,7 @@ class AuthOidcProvider(AuthProvider):
             }
 
             # Exchange code for token
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(trust_env=True) as session:
                 async with session.post(
                     token_endpoint, data=data
                 ) as response:


### PR DESCRIPTION
Hello,
If tugtainer have to use http_proxy to reach internet, aiohttp need to be able to read system variable (http_proxy)
https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support
This is native on requests but not on aiohttp .. https://github.com/aio-libs/aiohttp/issues/2963 
