### PR TITLE
fix: preserve host IP in port bindings during container recreation

### DIFF
--- a/backend/core/container/util/map_port_bindings_to_list.py
+++ b/backend/core/container/util/map_port_bindings_to_list.py
@@ -25,10 +25,16 @@ def map_port_bindings_to_list(
             if host_port:
                 host_ip = entry.host_ip
                 if host_ip:
-                    # Preserve specific IP binding (e.g. "192.168.1.6:443")
-                    # so the recreated container binds to the same address.
+                    # Preserve specific IP binding so the recreated
+                    # container binds to the same address.
+                    # IPv6 addresses must be wrapped in brackets
+                    # (e.g. [::1]:443) per Docker -p syntax.
+                    if ":" in host_ip:
+                        host_str = f"[{host_ip}]:{host_port}"
+                    else:
+                        host_str = f"{host_ip}:{host_port}"
                     result.append(
-                        (f"{host_ip}:{host_port}", container_port, proto)
+                        (host_str, container_port, proto)
                     )
                 else:
                     result.append((host_port, container_port, proto))


### PR DESCRIPTION
## Problem

When Tugtainer recreates a container that was originally bound to a specific IP address (e.g. `-p 10.0.0.5:443:443`), the recreated container binds to `0.0.0.0:443` instead. This causes port conflicts when another service on the same host is already listening on that port on a different IP.

In our case, we have two services that both need port 443 but on different IPs:
- Service A bound to `10.0.0.5:443`
- Service B bound to `10.0.0.10:443`

Every time Tugtainer updates Service A, it gets recreated on `0.0.0.0:443`, conflicting with Service B, and fails to start.

## Root Cause

`map_port_bindings_to_list()` reads `entry.host_port` from Docker's inspect data but ignores `entry.host_ip` entirely. The resulting tuple `(host_port, container_port, proto)` has no IP information, so Docker defaults to `0.0.0.0`.

## Fix

When `host_ip` is present, prepend it to `host_port` (e.g. `"10.0.0.5:443"`), which Docker CLI correctly interprets as an IP-specific binding via `-p 10.0.0.5:443:443/tcp`.

Containers without a specific IP binding are unaffected — they continue to use `0.0.0.0` as before.