### PR TITLE
feat(hosts): hide hosts with no matching containers when filtering available

### DIFF
--- a/backend/modules/hosts/hosts_router.py
+++ b/backend/modules/hosts/hosts_router.py
@@ -11,7 +11,10 @@ from .hosts_schemas import (
 )
 from backend.db.session import get_async_session
 from .hosts_model import HostsModel
-from backend.modules.hosts.hosts_util import get_host
+from backend.modules.hosts.hosts_util import (
+    annotate_available_updates_count,
+    get_host,
+)
 
 hosts_router = APIRouter(
     prefix="/hosts",
@@ -30,7 +33,9 @@ async def get_list(
 ):
     stmt = select(HostsModel)
     result = await session.execute(stmt)
-    return result.scalars().all()
+    hosts = list(result.scalars().all())
+    await annotate_available_updates_count(hosts, session)
+    return hosts
 
 
 @hosts_router.post(
@@ -59,6 +64,7 @@ async def create(
     await session.refresh(new_host)
     if new_host.enabled:
         await AgentClientManager.set_client(new_host)
+    await annotate_available_updates_count([new_host], session)
     return new_host
 
 
@@ -71,7 +77,9 @@ async def read(
     id: int,
     session: AsyncSession = Depends(get_async_session),
 ):
-    return await get_host(id, session)
+    host = await get_host(id, session)
+    await annotate_available_updates_count([host], session)
+    return host
 
 
 @hosts_router.put(
@@ -93,6 +101,7 @@ async def update(
     await AgentClientManager.remove_client(host.id)
     if host.enabled:
         await AgentClientManager.set_client(host)
+    await annotate_available_updates_count([host], session)
     return host
 
 

--- a/backend/modules/hosts/hosts_schemas.py
+++ b/backend/modules/hosts/hosts_schemas.py
@@ -16,6 +16,7 @@ class HostBase(BaseModel):
 
 class HostInfo(HostBase):
     id: int
+    available_updates_count: int = 0
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/backend/modules/hosts/hosts_util.py
+++ b/backend/modules/hosts/hosts_util.py
@@ -1,6 +1,7 @@
 from fastapi import HTTPException
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from backend.modules.containers.containers_model import ContainersModel
 from .hosts_model import HostsModel
 
 
@@ -12,3 +13,31 @@ async def get_host(host_id: int, session: AsyncSession) -> HostsModel:
     if not host:
         raise HTTPException(404, "Docker host not found in database")
     return host
+
+
+async def annotate_available_updates_count(
+    hosts: list[HostsModel], session: AsyncSession
+) -> None:
+    """Populate each host's ``available_updates_count`` ad-hoc attribute.
+
+    The count reflects containers on that host with ``update_available = True``.
+    Safe to call with an empty list.
+    """
+    if not hosts:
+        return
+    host_ids = [h.id for h in hosts]
+    stmt = (
+        select(
+            ContainersModel.host_id,
+            func.count(ContainersModel.id),
+        )
+        .where(
+            ContainersModel.host_id.in_(host_ids),
+            ContainersModel.update_available.is_(True),
+        )
+        .group_by(ContainersModel.host_id)
+    )
+    result = await session.execute(stmt)
+    counts = {host_id: cnt for host_id, cnt in result.all()}
+    for host in hosts:
+        host.available_updates_count = counts.get(host.id, 0)

--- a/backend/modules/hosts/test_hosts_util.py
+++ b/backend/modules/hosts/test_hosts_util.py
@@ -1,0 +1,57 @@
+import pytest
+from pytest_mock import MockerFixture
+from unittest.mock import MagicMock
+
+from backend.modules.hosts.hosts_util import (
+    annotate_available_updates_count,
+)
+
+
+@pytest.mark.asyncio
+async def test_annotate_noop_on_empty_list(mocker: MockerFixture):
+    session = mocker.AsyncMock()
+    session.execute = mocker.AsyncMock()
+
+    await annotate_available_updates_count([], session)
+
+    session.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_annotate_zero_when_query_returns_nothing(
+    mocker: MockerFixture,
+):
+    host = MagicMock()
+    host.id = 1
+
+    result = MagicMock()
+    result.all.return_value = []
+    session = mocker.AsyncMock()
+    session.execute = mocker.AsyncMock(return_value=result)
+
+    await annotate_available_updates_count([host], session)
+
+    assert host.available_updates_count == 0
+
+
+@pytest.mark.asyncio
+async def test_annotate_populates_counts_and_defaults_missing(
+    mocker: MockerFixture,
+):
+    host_a, host_b, host_c = MagicMock(), MagicMock(), MagicMock()
+    host_a.id, host_b.id, host_c.id = 1, 2, 3
+
+    result = MagicMock()
+    # host_c is intentionally absent from the query result; its count must
+    # fall back to 0.
+    result.all.return_value = [(1, 3), (2, 1)]
+    session = mocker.AsyncMock()
+    session.execute = mocker.AsyncMock(return_value=result)
+
+    await annotate_available_updates_count(
+        [host_a, host_b, host_c], session
+    )
+
+    assert host_a.available_updates_count == 3
+    assert host_b.available_updates_count == 1
+    assert host_c.available_updates_count == 0

--- a/frontend/src/app/features/containers/containers.component.html
+++ b/frontend/src/app/features/containers/containers.component.html
@@ -36,7 +36,7 @@
     [value]="accordionValue()"
     (valueChange)="accordionValue.set($event)"
   >
-    @for (h of hosts.value(); track h) {
+    @for (h of filteredHosts(); track h) {
       <p-accordion-panel
         [value]="h.id"
         [disabled]="!h.enabled"

--- a/frontend/src/app/features/containers/containers.component.ts
+++ b/frontend/src/app/features/containers/containers.component.ts
@@ -72,6 +72,17 @@ export class ContainersComponent extends WithHostsListDirective {
   protected readonly onlyAvailable = signal<boolean>(
     localStorage.getItemJson(onlyAvailableStorageKey) ?? false,
   );
+  /**
+   * Hosts displayed in the accordion. When {@link onlyAvailable} is true,
+   * hosts whose containers all have no update available are hidden.
+   */
+  protected readonly filteredHosts = computed(() => {
+    const hosts = this.hosts.value() ?? [];
+    if (!this.onlyAvailable()) {
+      return hosts;
+    }
+    return hosts.filter((h) => (h.available_updates_count ?? 0) > 0);
+  });
 
   constructor() {
     super();

--- a/frontend/src/app/features/hosts/hosts.interface.ts
+++ b/frontend/src/app/features/hosts/hosts.interface.ts
@@ -11,6 +11,7 @@ export interface ICreateHost {
 }
 export interface IHostInfo extends ICreateHost {
   id: number;
+  available_updates_count: number;
 }
 export interface IHostStatus {
   id: number;


### PR DESCRIPTION
When the "only available" filter is toggled, the containers table child component filters its rows, but the parent accordion still renders a panel for every host regardless of whether any containers remain after filtering. Hosts with zero pending updates show up as empty panels, cluttering the view on large deployments.

This change:

- Adds an `available_updates_count` field to `HostInfo` (backend), populated from a grouped COUNT over `containers.update_available = TRUE` via a new `annotate_available_updates_count` helper. The helper is applied to all endpoints that return `HostInfo` so the field is accurate everywhere the schema is exposed.
- Adds a `filteredHosts` computed signal on the containers component (frontend) that drops hosts with `available_updates_count === 0` when `onlyAvailable` is true; the template iterates this filtered list instead of the raw hosts list.
- Adds unit tests for the new helper.

No DB migration is required — the field is derived at query time.