### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,31 @@ Auth cookies are not domain-specific and not https only, but you can change this
 
 Starting with v1.6.0, you can use the OpenID Connect provider instead of password. This can also be configured using env variables.
 
+## Public API
+
+Tugtainer can expose a small auth-free public API when `ENABLE_PUBLIC_API=true`.
+
+- `GET /api/public/update_count`
+  - returns `{"total_updates": <number>}`
+  - shows the total number of containers currently marked as having available updates
+- `GET /api/public/summary`
+  - returns host/container summary statistics
+
+To enable this in Docker, set:
+
+```bash
+-e ENABLE_PUBLIC_API=true
+```
+
+Or in compose:
+
+```yaml
+services:
+  app:
+    environment:
+      - ENABLE_PUBLIC_API=true
+```
+
 ## Env:
 
 Environment variables are not required, but you can still define some. There is [.env.example](/.env.example) containing list of vars with description.

--- a/backend/modules/public/public_router.py
+++ b/backend/modules/public/public_router.py
@@ -8,6 +8,7 @@ from backend.db.session import get_async_session
 from backend.modules.public.public_util import fetch_latest_release
 from .public_schemas import (
     IsUpdateAvailableResponseBodySchema,
+    TotalUpdateCountResponseBodySchema,
     VersionResponseBody,
 )
 from backend.core.cron_manager import CronManager
@@ -178,6 +179,43 @@ async def get_summary(
         )
 
     return summaries
+
+
+@public_router.get(
+    "/update_count",
+    description="Get total number of containers with available updates",
+    response_model=TotalUpdateCountResponseBodySchema,
+)
+async def get_update_count(
+    session: AsyncSession = Depends(get_async_session),
+) -> TotalUpdateCountResponseBodySchema:
+    if not Config.ENABLE_PUBLIC_API:
+        raise HTTPException(404, "Not Found")
+
+    stmt = select(HostsModel).where(HostsModel.enabled == True)
+    result = await session.execute(stmt)
+    hosts = result.scalars().all()
+
+    total_updates = 0
+    for host in hosts:
+        client = AgentClientManager.get_host_client(host)
+        containers = await client.container.list(
+            GetContainerListBodySchema(all=True)
+        )
+        db_result = await session.execute(
+            select(ContainersModel).where(
+                ContainersModel.host_id == host.id
+            )
+        )
+        containers_db = db_result.scalars().all()
+        containers_db_map = {item.name: item for item in containers_db}
+
+        for container in containers:
+            db_item = containers_db_map.get(container.name)
+            if db_item and db_item.update_available:
+                total_updates += 1
+
+    return {"total_updates": total_updates}
 
 
 @public_router.get(

--- a/backend/modules/public/public_schemas.py
+++ b/backend/modules/public/public_schemas.py
@@ -11,6 +11,10 @@ class IsUpdateAvailableResponseBodySchema(BaseModel):
 
 
 
+class TotalUpdateCountResponseBodySchema(BaseModel):
+    total_updates: int
+
+
 class VersionResponseBody(BaseModel):
     """Versions schema"""
 

--- a/backend/modules/public/test_public_router.py
+++ b/backend/modules/public/test_public_router.py
@@ -52,3 +52,83 @@ async def test_is_update_available(
     data = response.json()
     assert data["is_available"] == expected_is_available
     assert data["release_url"] == expected_release_url
+
+
+@pytest.mark.asyncio
+async def test_get_update_count(
+    mocker: MockerFixture,
+):
+    from backend.modules.public.public_router import (
+        Config,
+    )
+    from backend.modules.containers.containers_model import (
+        ContainersModel,
+    )
+    from backend.modules.hosts.hosts_model import (
+        HostsModel,
+    )
+
+    mocker.patch(
+        f"{module_path}.Config.ENABLE_PUBLIC_API",
+        True,
+    )
+
+    fake_host = HostsModel(
+        id=1,
+        name="host1",
+        enabled=True,
+        url="http://example",
+        secret=None,
+        ssl=True,
+        timeout=5,
+        container_hc_timeout=60,
+        prune=False,
+        prune_all=False,
+    )
+    fake_container_db = ContainersModel(
+        host_id=1,
+        name="container1",
+        check_enabled=False,
+        update_enabled=False,
+        update_available=True,
+        image_id=None,
+    )
+
+    fake_session = mocker.Mock()
+
+    async def fake_execute(statement):
+        stmt_text = str(statement).lower()
+        result = mocker.Mock()
+        result.scalars.return_value = result
+        if "from hosts" in stmt_text:
+            result.all.return_value = [fake_host]
+            return result
+        if "from containers" in stmt_text:
+            result.all.return_value = [fake_container_db]
+            return result
+        raise AssertionError(f"Unexpected statement: {stmt_text}")
+
+    fake_session.execute = mocker.AsyncMock(side_effect=fake_execute)
+
+    async def fake_get_async_session():
+        yield fake_session
+
+    mocker.patch(
+        f"{module_path}.get_async_session",
+        fake_get_async_session,
+    )
+
+    fake_client = mocker.Mock()
+    fake_container = mocker.Mock()
+    fake_container.name = "container1"
+    fake_client.container.list = mocker.AsyncMock(
+        return_value=[fake_container]
+    )
+    mocker.patch(
+        f"{module_path}.AgentClientManager.get_host_client",
+        return_value=fake_client,
+    )
+
+    response = client.get("/public/update_count")
+    assert response.status_code == 200
+    assert response.json() == {"total_updates": 1}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,6 +33,7 @@ services:
         VERSION: dev build
     environment:
       AGENT_SECRET: testsecret
+      ENABLE_PUBLIC_API: "true"
       LOG_LEVEL: info
       DOCKER_HOST: tcp://socket-proxy:2375
     volumes:


### PR DESCRIPTION
## Public API

Tugtainer can expose a small auth-free public API when `ENABLE_PUBLIC_API=true`.

- `GET /api/public/update_count`
  - returns `{"total_updates": <number>}`
  - shows the total number of containers currently marked as having available updates
- `GET /api/public/summary`
  - returns host/container summary statistics